### PR TITLE
Fix code scanning alert no. 62: Too few arguments to formatting function

### DIFF
--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -330,7 +330,7 @@ defnodeCount(node, res, cap, total)
 	if (pwr && (!strcmp(cp, pwr)))
 	{
 	    /* Diagnostic */
-	    TxPrintf("Node %s matches VDD variable definition!\n");
+	    TxPrintf("Node %s matches VDD variable definition!\n", cp);
 	    node->efnode_flags |= EF_SPECIAL;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/62](https://github.com/dlmiles/magic/security/code-scanning/62)

To fix the problem, we need to provide the missing argument to the `TxPrintf` function call on line 333. The argument should be the node name (`cp`), which is consistent with the other `TxPrintf` calls in the same context. This will ensure that the format string has the correct number of arguments, preventing potential undefined behavior or security vulnerabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
