### PR TITLE
Fix code scanning alert no. 156: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,92 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '22 5 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: manual
+        - language: python
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        sudo apt-get install -y tcl-dev tk-dev libcairo-dev
+        ./configure
+        make database/database.h
+        make -j$(nproc)
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/router/rtrCmd.c
+++ b/router/rtrCmd.c
@@ -640,7 +640,7 @@ CmdRoute(w, cmd)
 	    {
 		if(cmd->tx_argc!=3)
 		    goto wrongNumArgs;
-		if(!sscanf(cmd->tx_argv[2], "%d", &RtrViaLimit))
+		if(sscanf(cmd->tx_argv[2], "%d", &RtrViaLimit) != 1)
 		    TxError("Bad value for via limit\n");
 	    }
 	    TxPrintf("Via limit is %d\n", RtrViaLimit);
@@ -650,7 +650,7 @@ CmdRoute(w, cmd)
 	    {
 		if(cmd->tx_argc!=3)
 		    goto wrongNumArgs;
-		if(!sscanf(cmd->tx_argv[2], "%f", &RtrEndConst))
+		if(sscanf(cmd->tx_argv[2], "%f", &RtrEndConst) != 1)
 		    TxError("Bad value for channel end distance\n");
 	    }
 	    TxPrintf("Channel end constant is %f\n", RtrEndConst);
@@ -660,7 +660,7 @@ CmdRoute(w, cmd)
 	    {
 		if(cmd->tx_argc!=3)
 		    goto wrongNumArgs;
-		if(!sscanf(cmd->tx_argv[2], "%d", &GCRMinJog))
+		if(sscanf(cmd->tx_argv[2], "%d", &GCRMinJog) != 1)
 		    TxError("Bad value for minimum jog length\n");
 	    }
 	    TxPrintf("Minimum jog length is %d\n", GCRMinJog);
@@ -670,7 +670,7 @@ CmdRoute(w, cmd)
 	    {
 		if(cmd->tx_argc!=3)
 		    goto wrongNumArgs;
-		if(!sscanf(cmd->tx_argv[2], "%f", &GCRObstDist))
+		if(sscanf(cmd->tx_argv[2], "%f", &GCRObstDist) != 1)
 		    TxError("Bad value for obstacle constant\n");
 	    }
 	    TxPrintf("Obstacle constant is %f\n", GCRObstDist);
@@ -680,7 +680,7 @@ CmdRoute(w, cmd)
 	    {
 		if(cmd->tx_argc!=3)
 		    goto wrongNumArgs;
-		if(!sscanf(cmd->tx_argv[2], "%d", &GCRSteadyNet))
+		if(sscanf(cmd->tx_argv[2], "%d", &GCRSteadyNet) != 1)
 		    TxError("Bad value for steady net constant\n");
 	    }
 	    TxPrintf("Steady net constant is %d\n", GCRSteadyNet);


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/156](https://github.com/dlmiles/magic/security/code-scanning/156)

To fix the problem, we need to ensure that the return value of `sscanf` is checked against the expected number of arguments rather than just zero. Specifically, we should check if the return value is less than the expected number of items to be read (in this case, 1). If the return value is less than 1, it indicates either an input failure (`EOF`) or that no items were successfully read, both of which should be handled appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
