### PR TITLE
Fix code scanning alert no. 10: Call to function with fewer arguments than declared parameters

### DIFF
--- a/database/DBcellname.c
+++ b/database/DBcellname.c
@@ -283,7 +283,7 @@ DBCellDelete(cellname, force)
     /* so that WindUnload() will create a new one.			*/
 
     if (!strcmp(cellname, UNNAMED))
-	DBCellRename(cellname, "__UNNAMED__");
+	DBCellRename(cellname, "__UNNAMED__", FALSE);
 
     /* For all top-level cell uses, check if any windows have this	*/
     /* use.  If so, load the window with (UNNAMED).			*/


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/10](https://github.com/dlmiles/magic/security/code-scanning/10)

To fix the problem, we need to call `DBCellRename` with the correct number of arguments. The function expects three arguments: `cellname`, `newname`, and `doforce`. In the context of the provided code, we need to determine appropriate values for `newname` and `doforce`. Since the function is called when the cell name is "UNNAMED", we can use the string `"__UNNAMED__"` for `newname` as it seems to be the intended new name. For `doforce`, we can use a boolean value, and based on the context, `FALSE` seems appropriate as there is no indication that forcing the rename is necessary.

AI resolution is same as mine, human rationale:

Call to function with fewer arguments than declared parameters
    
Resolution assumes original behaviour from (231a299 2017-04-25) before the extra argument was added to function DBCellRename().
    
Related commit (adding extra argument to function) :
    
commit 07e366ad8a08978fde5b574380e3aad0fb4e731c (tag: 8.3.193)
Date:   Thu Jul 29 17:34:39 2021 -0400
    
CodeQL: https://github.com/dlmiles/magic/security/code-scanning/10


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
