### PR TITLE
Fix code scanning alert no. 9: Call to function with fewer arguments than declared parameters

### DIFF
--- a/database/DBcellcopy.c
+++ b/database/DBcellcopy.c
@@ -603,7 +603,7 @@ DBFlattenInPlace(use, dest, xMask, dolabels, toplabels, doclear)
 	{
 	    int savemask = scx.scx_use->cu_expandMask;
 	    scx.scx_use->cu_expandMask = CU_DESCEND_SPECIAL;
-	    DBCellCopyAllLabels(&scx, &DBAllTypeBits, CU_DESCEND_SPECIAL, dest);
+	    DBCellCopyAllLabels(&scx, &DBAllTypeBits, CU_DESCEND_SPECIAL, dest, NULL);
 	    scx.scx_use->cu_expandMask = savemask;
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/9](https://github.com/dlmiles/magic/security/code-scanning/9)

To fix the problem, we need to call the `DBCellCopyAllLabels` function with the correct number of arguments. Specifically, we need to provide a fifth argument for the `pArea` parameter. Since the original call does not provide this argument, we can pass `NULL` if the bounding box of the copied labels is not needed, which aligns with the function's documentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
