### PR TITLE
Fix code scanning alert no. 117: Wrong type of arguments to formatting function

### DIFF
--- a/utils/undo.c
+++ b/utils/undo.c
@@ -924,8 +924,8 @@ undoPrintForw(iup, n)
 {
     int i = 0;
 
-    (void) TxPrintf("head=0x%x\ttail=0x%x\tcur=0x%x\n",
-		undoLogHead, undoLogTail, undoLogCur);
+    (void) TxPrintf("head=%p\ttail=%p\tcur=%p\n",
+		(void *)undoLogHead, (void *)undoLogTail, (void *)undoLogCur);
     if (iup == (internalUndoEvent *) NULL)
 	iup = undoLogHead;
     while (iup != (internalUndoEvent *) NULL)
@@ -947,8 +947,8 @@ undoPrintBack(iup, n)
 {
     int i = 0;
 
-    (void) TxPrintf("head=0x%x\ttail=0x%x\tcur=0x%x\n",
-		undoLogHead, undoLogTail, undoLogCur);
+    (void) TxPrintf("head=%p\ttail=%p\tcur=%p\n",
+		(void *)undoLogHead, (void *)undoLogTail, (void *)undoLogCur);
     if (iup == (internalUndoEvent *) NULL)
 	iup = undoLogTail;
     while (iup != (internalUndoEvent *) NULL)


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/117](https://github.com/dlmiles/magic/security/code-scanning/117)

To fix the problem, we need to update the format specifier in the `TxPrintf` function calls to correctly match the type of the arguments. Specifically, we should use `%p` for printing pointer values. This change ensures that the pointers are printed in a standard format, avoiding undefined behavior or incorrect output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
