### PR TITLE
Fix code scanning alert no. 120: Wrong type of arguments to formatting function

### DIFF
--- a/utils/undo.c
+++ b/utils/undo.c
@@ -910,8 +910,8 @@ undoPrintEvent(iup)
     else
 	client_name = undoClientTable[iup->iue_type].uc_name;
 
-    (void) TxPrintf("0x%x: \t%s \tf=0x%x \tb=0x%x\n",
-		iup, client_name, iup->iue_forw, iup->iue_back);
+    (void) TxPrintf("0x%p: \t%s \tf=0x%p \tb=0x%p\n",
+		(void *)iup, client_name, (void *)iup->iue_forw, (void *)iup->iue_back);
 }
 
 /* Print events forward from "iup".  If n is 0 or negative, print to	*/
@@ -924,8 +924,8 @@ undoPrintForw(iup, n)
 {
     int i = 0;
 
-    (void) TxPrintf("head=0x%x\ttail=0x%x\tcur=0x%x\n",
-		undoLogHead, undoLogTail, undoLogCur);
+    (void) TxPrintf("head=0x%p\ttail=0x%p\tcur=0x%p\n",
+		(void *)undoLogHead, (void *)undoLogTail, (void *)undoLogCur);
     if (iup == (internalUndoEvent *) NULL)
 	iup = undoLogHead;
     while (iup != (internalUndoEvent *) NULL)
@@ -947,8 +947,8 @@ undoPrintBack(iup, n)
 {
     int i = 0;
 
-    (void) TxPrintf("head=0x%x\ttail=0x%x\tcur=0x%x\n",
-		undoLogHead, undoLogTail, undoLogCur);
+    (void) TxPrintf("head=0x%p\ttail=0x%p\tcur=0x%p\n",
+		(void *)undoLogHead, (void *)undoLogTail, (void *)undoLogCur);
     if (iup == (internalUndoEvent *) NULL)
 	iup = undoLogTail;
     while (iup != (internalUndoEvent *) NULL)


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/120](https://github.com/dlmiles/magic/security/code-scanning/120)

To fix the problem, we need to change the format specifier from `%x` to `%p` in the `TxPrintf` function calls. The `%p` format specifier is used to print pointer addresses and is the correct format for the `internalUndoEvent *` type. This change ensures that the pointer addresses are printed correctly and avoids any undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
