### PR TITLE
Fix code scanning alert no. 116: Wrong type of arguments to formatting function

### DIFF
--- a/textio/txCommands.c
+++ b/textio/txCommands.c
@@ -201,7 +201,7 @@ void
 TxPrintEvent(event)
     TxInputEvent *event;
 {
-    TxError("Input event at 0x%x\n    ", event);
+    TxError("Input event at %p\n    ", event);
     if (event->txe_button == TX_EOF) {
 	TxError("EOF event");
     } else if (event->txe_button == TX_BYPASS) {


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/116](https://github.com/dlmiles/magic/security/code-scanning/116)

To fix the problem, we need to ensure that the format specifier matches the type of the argument being passed. Since `event` is a pointer, we should use the `%p` format specifier, which is designed for pointer types. This change will ensure that the memory address of the `event` pointer is correctly formatted and printed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
