### PR TITLE
Fix code scanning alert no. 115: Wrong type of arguments to formatting function

### DIFF
--- a/textio/txCommands.c
+++ b/textio/txCommands.c
@@ -255,7 +255,7 @@ TxPrintCommand(cmd)
     int i, j;
     char TxTemp[200];
 
-    TxError("Command at 0x%x\n    ", cmd);
+    TxError("Command at %p\n    ", cmd);
     if (cmd->tx_button == TX_CHARACTER) {
 	TxError("Text command with %d words: ", cmd->tx_argc);
 	for (i = 0; i < cmd->tx_argc; i++) {


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/115](https://github.com/dlmiles/magic/security/code-scanning/115)

To fix the problem, we need to ensure that the format specifier matches the type of the argument being passed. Since `cmd` is a pointer, we should use the `%p` format specifier, which is designed for pointer types. This change will correctly format the pointer value and avoid any undefined behavior.

The specific change involves modifying the format specifier in the `TxError` function call on line 258 of the file `textio/txCommands.c`. No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
