### PR TITLE
Fix code scanning alert no. 114: Wrong type of arguments to formatting function

### DIFF
--- a/textio/txCommands.c
+++ b/textio/txCommands.c
@@ -639,7 +639,7 @@ TxLogStart(fileName, mw)
 {
     if (txLogFile != NULL)
     {
-	TxError("There is already a log file (%s) open!\n", txLogFile);
+	TxError("There is already a log file open!\n");
 	return;
     }
 


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/114](https://github.com/dlmiles/magic/security/code-scanning/114)

To fix the problem, we need to ensure that the format specifier matches the type of the argument being passed to the `TxError` function. Since `txLogFile` is of type `FILE*`, we should not use the `%s` format specifier. Instead, we can use the file name associated with `txLogFile` if available, or simply indicate that a log file is already open without specifying its name.

- Change the format specifier from `%s` to a more appropriate message that does not require the file name.
- Update the `TxError` call to reflect this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
