### PR TITLE
Fix code scanning alert no. 138: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -389,7 +389,7 @@ extBasic(def, outFile)
 	    if (propfound)
 	    {
 		token = strtok(NULL, " ");
-		if ((token == NULL) || !sscanf(token, "%d", &llx))
+		if ((token == NULL) || (sscanf(token, "%d", &llx) != 1))
 		    propfound = FALSE;
 		else
 		    llx *= ExtCurStyle->exts_unitsPerLambda;
@@ -397,7 +397,7 @@ extBasic(def, outFile)
 	    if (propfound)
 	    {
 		token = strtok(NULL, " ");
-		if ((token == NULL) || !sscanf(token, "%d", &lly))
+		if ((token == NULL) || (sscanf(token, "%d", &lly) != 1))
 		    propfound = FALSE;
 		else
 		    lly *= ExtCurStyle->exts_unitsPerLambda;


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/138](https://github.com/dlmiles/magic/security/code-scanning/138)

To fix the problem, we need to ensure that the return value of `sscanf` is checked against the expected number of arguments rather than just non-zero. Specifically, we should check if `sscanf` returns `1` (indicating one successful match) and handle the `EOF` case appropriately.

1. Identify the lines where `sscanf` is used and the return value is checked.
2. Modify the condition to check if the return value is equal to `1` (the expected number of matches).
3. Handle the case where `sscanf` returns `EOF` by setting `propfound` to `FALSE`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
