### PR TITLE
Fix code scanning alert no. 140: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -389,7 +389,7 @@ extBasic(def, outFile)
 	    if (propfound)
 	    {
 		token = strtok(NULL, " ");
-		if ((token == NULL) || !sscanf(token, "%d", &llx))
+		if ((token == NULL) || (sscanf(token, "%d", &llx) != 1))
 		    propfound = FALSE;
 		else
 		    llx *= ExtCurStyle->exts_unitsPerLambda;
@@ -397,7 +397,7 @@ extBasic(def, outFile)
 	    if (propfound)
 	    {
 		token = strtok(NULL, " ");
-		if ((token == NULL) || !sscanf(token, "%d", &lly))
+		if ((token == NULL) || (sscanf(token, "%d", &lly) != 1))
 		    propfound = FALSE;
 		else
 		    lly *= ExtCurStyle->exts_unitsPerLambda;
@@ -405,7 +405,7 @@ extBasic(def, outFile)
 	    if (propfound)
 	    {
 		token = strtok(NULL, " ");
-		if ((token == NULL) || !sscanf(token, "%d", &urx))
+		if ((token == NULL) || (sscanf(token, "%d", &urx) != 1))
 		    propfound = FALSE;
 		else
 		    urx *= ExtCurStyle->exts_unitsPerLambda;
@@ -414,7 +414,7 @@ extBasic(def, outFile)
 	    if (propfound)
 	    {
 		token = strtok(NULL, " ");
-		if ((token == NULL) || !sscanf(token, "%d", &ury))
+		if ((token == NULL) || (sscanf(token, "%d", &ury) != 1))
 		    propfound = FALSE;
 		else
 		    ury *= ExtCurStyle->exts_unitsPerLambda;


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/140](https://github.com/dlmiles/magic/security/code-scanning/140)

To fix the problem, we need to ensure that the return value of `sscanf` is checked against the expected number of arguments rather than just non-zero. Specifically, we should check if `sscanf` successfully reads one integer from the token. If it does not, we should handle the error appropriately by setting `propfound` to `FALSE`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
