### PR TITLE
Fix code scanning alert no. 129: Wrong type of arguments to formatting function

### DIFF
--- a/windows/windDebug.c
+++ b/windows/windDebug.c
@@ -106,7 +106,7 @@ windDump()
     for (rc = windFirstClientRec; rc != (clientRec * ) NULL;
 	rc = rc->w_nextClient)
     {
-	TxPrintf("'%10s'  %x %x %x %x\n", rc->w_clientName,
+	TxPrintf("'%10s'  %p %p %p %p\n", rc->w_clientName,
 	    rc->w_create, rc->w_delete,
 	    rc->w_redisplay, rc->w_command);
     }

--- a/windows/windDebug.c
+++ b/windows/windDebug.c
@@ -21,6 +21,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #endif  /* not lint */
 
 #include <stdio.h>
+#include <stdint.h>
 
 #include "utils/magic.h"
 #include "utils/geometry.h"
@@ -106,9 +107,9 @@ windDump()
     for (rc = windFirstClientRec; rc != (clientRec * ) NULL;
 	rc = rc->w_nextClient)
     {
-	TxPrintf("'%10s'  %p %p %p %p\n", rc->w_clientName,
-	    rc->w_create, rc->w_delete,
-	    rc->w_redisplay, rc->w_command);
+	TxPrintf("'%10s'  %lx %lx %lx %lx\n", rc->w_clientName,
+	    (intmax_t) rc->w_create, (intmax_t) rc->w_delete,
+	    (intmax_t) rc->w_redisplay, (intmax_t) rc->w_command);
     }
 
     TxPrintf("\n");


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/129](https://github.com/dlmiles/magic/security/code-scanning/129)

To fix the problem, we need to change the format specifier from `%x` to `%p` for the function pointers in the `TxPrintf` call. This ensures that the function pointers are printed correctly and portably. The change should be made in the `windDump` function, specifically on line 111.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
