### PR TITLE
Fix code scanning alert no. 113: Wrong type of arguments to formatting function

### DIFF
--- a/resis/ResRex.c
+++ b/resis/ResRex.c
@@ -945,8 +945,8 @@ ResCheckPorts(cellDef)
 		/* and a drivepoint.					*/
 
 		node = ResInitializeNode(entry);
-		TxPrintf("Port: name = %s is new node 0x%x\n",
-			lab->lab_text, node);
+		TxPrintf("Port: name = %s is new node %p\n",
+			lab->lab_text, (void *)node);
 		TxPrintf("Location is (%d, %d); drivepoint (%d, %d)\n",
 			portloc.p_x, portloc.p_y,
 			portloc.p_x, portloc.p_y);


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/113](https://github.com/dlmiles/magic/security/code-scanning/113)

To fix the problem, we need to change the format specifier from `%x` to `%p` to correctly print the address of the `node` pointer. This change ensures that the format specifier matches the argument type, preventing undefined behavior and ensuring the correct output.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
