### PR TITLE
Fix code scanning alert no. 103: Wrong type of arguments to formatting function

### DIFF
--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -307,8 +307,8 @@ PlowTest(w, cmd)
 	    tp = TiSrPointNoHint(plane, &editArea.r_ll);
 	    if (cmd->tx_argc == 3) trail = atoi(cmd->tx_argv[2]);
 	    else trail = editArea.r_xtop;
-	    TxPrintf("Trailing coordinate of tile 0x%x updated from %d to %d\n",
-			tp, TRAILING(tp), trail);
+	    TxPrintf("Trailing coordinate of tile %p updated from %d to %d\n",
+			(void *)tp, TRAILING(tp), trail);
 	    plowSetTrailing(tp, trail);
 	    break;
 	case PC_MOVE:


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/103](https://github.com/dlmiles/magic/security/code-scanning/103)

To fix the problem, we need to change the format specifier from `%x` to `%p` in the `TxPrintf` function call. This change ensures that the pointer `tp` is printed correctly according to the standard C format specifiers.

- Change the format specifier from `%x` to `%p` in the `TxPrintf` function call on line 311.
- Ensure that the argument `tp` is correctly passed to the `TxPrintf` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
