### PR TITLE
Fix code scanning alert no. 104: Wrong type of arguments to formatting function

### DIFF
--- a/plow/PlowTest.c
+++ b/plow/PlowTest.c
@@ -328,8 +328,8 @@ PlowTest(w, cmd)
 		return;
 	    }
 	    TiToRect(tp, &area2);
-	    TxPrintf("Splitting tile 0x%x at y=%d yielding 0x%x\n",
-			tp, editArea.r_ybot, plowSplitY(tp, editArea.r_ybot));
+	    TxPrintf("Splitting tile %p at y=%d yielding %p\n",
+			(void *)tp, editArea.r_ybot, (void *)plowSplitY(tp, editArea.r_ybot));
 	    DBWAreaChanged(def, &area2, DBW_ALLWINDOWS, &DBAllButSpaceBits);
 	    break;
 	case PC_MERGEDOWN:


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/104](https://github.com/dlmiles/magic/security/code-scanning/104)

To fix the problem, we need to use the correct format specifier for a pointer type. In C, the `%p` format specifier is used for printing pointers. This ensures that the pointer is printed in a way that is appropriate for the system's architecture.

- Change the format specifier from `%x` to `%p` for the `tp` variable.
- Ensure that the argument passed to the format specifier is cast to `void *` to match the `%p` specifier's expected type.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
