### PR TITLE
Fix code scanning alert no. 100: Wrong type of arguments to formatting function

### DIFF
--- a/grouter/grouteTest.c
+++ b/grouter/grouteTest.c
@@ -371,9 +371,9 @@ glShowCross(pin, netId, kind)
     {
 	(void) strcpy(name1, NLNetName(pin->gcr_pId));
 	(void) strcpy(name2, NLNetName(netId.netid_net));
-	TxPrintf("%s (%d,%d), Net %s/%d->%s/%d, Ch %d\n",
+	TxPrintf("%s (%d,%d), Net %s/%d->%s/%d, Ch %p\n",
 		name, pin->gcr_point.p_x, pin->gcr_point.p_y,
-		name1, pin->gcr_pSeg, name2, netId.netid_seg, pin->gcr_ch);
+		name1, pin->gcr_pSeg, name2, netId.netid_seg, (void *)pin->gcr_ch);
     }
 
     r.r_ll = r.r_ur = pin->gcr_point;

--- a/grouter/grouteTest.c
+++ b/grouter/grouteTest.c
@@ -21,6 +21,7 @@ static char rcsid[] __attribute__ ((unused)) = "$Header: /usr/cvsroot/magic-8.0/
 #endif  /* not lint */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -371,9 +372,9 @@ glShowCross(pin, netId, kind)
     {
 	(void) strcpy(name1, NLNetName(pin->gcr_pId));
 	(void) strcpy(name2, NLNetName(netId.netid_net));
-	TxPrintf("%s (%d,%d), Net %s/%d->%s/%d, Ch %p\n",
+	TxPrintf("%s (%d,%d), Net %s/%d->%s/%d, Ch %ld\n",
 		name, pin->gcr_point.p_x, pin->gcr_point.p_y,
-		name1, pin->gcr_pSeg, name2, netId.netid_seg, (void *)pin->gcr_ch);
+		name1, pin->gcr_pSeg, name2, netId.netid_seg, (intmax_t) pin->gcr_ch);
     }
 
     r.r_ll = r.r_ur = pin->gcr_point;


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/100](https://github.com/dlmiles/magic/security/code-scanning/100)

To fix the problem, we need to ensure that the format specifier in the `TxPrintf` call matches the type of `pin->gcr_ch`. If `pin->gcr_ch` is of type `chan *`, we should use a format specifier that correctly represents a pointer type, such as `%p`. This will ensure that the argument is correctly interpreted and printed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
