### PR TITLE
Fix code scanning alert no. 66: Wrong type of arguments to formatting function

### DIFF
--- a/database/DBcellsrch.c
+++ b/database/DBcellsrch.c
@@ -1621,7 +1621,7 @@ dbTileScaleFunc(tile, scvals)
     if ((targetRect.r_xtop - targetRect.r_xbot == 0) ||
 		(targetRect.r_ytop - targetRect.r_ybot == 0))
     {
-	TxPrintf("Tile 0x%x at (%d, %d) has zero area after scaling:  Removed.\n",
+	TxPrintf("Tile %p at (%d, %d) has zero area after scaling:  Removed.\n",
 		tile, targetRect.r_xbot, targetRect.r_ybot);
 	return 0;
     }


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/66](https://github.com/dlmiles/magic/security/code-scanning/66)

To fix the problem, we need to change the format specifier in the `TxPrintf` function call to match the type of the `tile` argument. Since `tile` is a pointer, the correct format specifier to use is `%p`, which is designed for printing pointer values.

- Change the format specifier from `%x` to `%p` in the `TxPrintf` function call on line 1625.
- Ensure that the pointer value is correctly printed, which will provide useful debugging information without causing undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
