### PR TITLE
Fix code scanning alert no. 65: Wrong type of arguments to formatting function

### DIFF
--- a/commands/CmdWizard.c
+++ b/commands/CmdWizard.c
@@ -976,7 +976,7 @@ cmdTsrFunc(tp)
     Tile *tp;
 {
     if (cmdTsearchDebug)
-	TxPrintf("%x\n", tp);
+	TxPrintf("%p\n", tp);
     numTilesFound++;
     return 0;
 }


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/65](https://github.com/dlmiles/magic/security/code-scanning/65)

To fix the problem, we need to change the format specifier from `%x` to `%p`, which is the correct format specifier for printing pointer values. This ensures that the pointer is printed in a portable and defined manner.

- Change the format specifier in the `TxPrintf` call on line 979 from `%x` to `%p`.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
