### PR TITLE
Fix code scanning alert no. 61: Too few arguments to formatting function

### DIFF
--- a/extract/ExtTech.c
+++ b/extract/ExtTech.c
@@ -2986,7 +2986,7 @@ ExtTechLine(sectionName, argc, argv)
 		    ExtCurStyle->exts_antennaModel |= ANTENNAMODEL_SIDEWALL;
 		else
 		    TxError("Unknown antenna model \"%s\":  Use \"surface\" or "
-				    "\"sidewall\"");
+				    "\"sidewall\"", argv[2]);
 	    }
 	    break;
 


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/61](https://github.com/dlmiles/magic/security/code-scanning/61)

To fix the problem, we need to ensure that the `TxError` function call on line 2988 receives the correct number of arguments as specified by the format string. Specifically, the format string expects one argument to replace the `%s` placeholder. We should pass `argv[2]` as the argument to match the format string.

- **General fix:** Ensure that all format specifiers in the format string have corresponding arguments.
- **Detailed fix:** Modify the `TxError` call on line 2988 to include `argv[2]` as the argument for the `%s` placeholder.
- **Specific changes:** Update the `TxError` call on line 2988 in the file `extract/ExtTech.c`.
- **Requirements:** No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
