### PR TITLE
Fix code scanning alert no. 60: Too few arguments to formatting function

### DIFF
--- a/extract/ExtTech.c
+++ b/extract/ExtTech.c
@@ -2976,7 +2976,7 @@ ExtTechLine(sectionName, argc, argv)
 		ExtCurStyle->exts_antennaModel |= ANTENNAMODEL_CUMULATIVE;
 	    else
 		TxError("Unknown antenna model \"%s\":  Use \"partial\" or "
-			    "\"cumulative\"");
+			    "\"cumulative\"", argv[1]);
 
 	    if (argc > 2)
 	    {


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/60](https://github.com/dlmiles/magic/security/code-scanning/60)

To fix the problem, we need to ensure that the `TxError` function call on line 2978 includes the required argument that matches the `%s` format specifier in the format string. The missing argument should be the unknown antenna model, which is `argv[1]` in this context.

- Update the `TxError` call to include `argv[1]` as the argument.
- This change should be made in the file `extract/ExtTech.c` on line 2978.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
