### PR TITLE
Fix code scanning alert no. 71: Wrong type of arguments to formatting function

### DIFF
--- a/extract/ExtHier.c
+++ b/extract/ExtHier.c
@@ -854,7 +854,7 @@ extOutputConns(table, outf)
 		fprintf(outf, "merge \"%s\" \"%s\" %lg",
 				nn->nn_name, nnext->nn_name, c);
 		for (n = 0; n < ExtCurStyle->exts_numResistClasses; n++)
-		    fprintf(outf, " %d %d",
+		    fprintf(outf, " %ld %ld",
 				node->node_pa[n].pa_area,
 				node->node_pa[n].pa_perim);
 		fprintf(outf, "\n");


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/71](https://github.com/dlmiles/magic/security/code-scanning/71)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since CodeQL indicates that `pa_area` is of type `signed long`, we should use the `%ld` format specifier instead of `%d`. This change will ensure that the `fprintf` function correctly interprets the argument type, preventing any undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
