### PR TITLE
Fix code scanning alert no. 23: Call to function with fewer arguments than declared parameters

### DIFF
--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -441,7 +441,7 @@ char *defHNsprintfPrefix(hierName, str, divchar)
     char *cp, c;
 
     if (hierName->hn_parent)
-	str = defHNsprintfPrefix(hierName->hn_parent, str);
+	str = defHNsprintfPrefix(hierName->hn_parent, str, divchar);
 
     cp = hierName->hn_name;
     while (*str++ = *cp++) ;


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/23](https://github.com/dlmiles/magic/security/code-scanning/23)

To fix the problem, we need to ensure that the `defHNsprintfPrefix` function is called with the correct number of arguments. Specifically, we need to pass the `divchar` argument in the recursive call on line 444. This will ensure that the function has all the information it needs to operate correctly and prevent any undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
