### PR TITLE
Fix code scanning alert no. 132: Redundant null check due to previous dereference

### DIFF
--- a/database/DBio.c
+++ b/database/DBio.c
@@ -1950,6 +1950,7 @@ badTransform:
     /* points to a different target, then flag an error, as there are	*/
     /* now two versions of the same cell name coming from different	*/
     /* sources, and this must be corrected.				*/
+
     if (*pathptr != '\0')
     {
 	if (subCellDef->cd_file != NULL)

--- a/database/DBio.c
+++ b/database/DBio.c
@@ -1950,7 +1950,7 @@ badTransform:
     /* points to a different target, then flag an error, as there are	*/
     /* now two versions of the same cell name coming from different	*/
     /* sources, and this must be corrected.				*/
-    if (pathptr != NULL && *pathptr != '\0')
+    if (*pathptr != '\0')
     {
 	if (subCellDef->cd_file != NULL)
 	{

--- a/database/DBio.c
+++ b/database/DBio.c
@@ -1950,8 +1950,7 @@ badTransform:
     /* points to a different target, then flag an error, as there are	*/
     /* now two versions of the same cell name coming from different	*/
     /* sources, and this must be corrected.				*/
-
-    if (*pathptr != '\0')
+    if (pathptr != NULL && *pathptr != '\0')
     {
 	if (subCellDef->cd_file != NULL)
 	{
@@ -2148,7 +2147,7 @@ badTransform:
 	    /* default path but the new cell has a (different) path.	*/
 	    /* The paths only match if pathptr is the CWD.		*/
 
-	    else if ((pathptr != NULL) && (*pathptr != '\0'))
+	    else if (*pathptr != '\0')
 	    {
 		bool pathOK = FALSE;
 		char *cwddir = getenv("PWD");


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/132](https://github.com/dlmiles/magic/security/code-scanning/132)

To fix the problem, we need to move the null check for `pathptr` before its dereference. This will ensure that `pathptr` is not null before we attempt to dereference it, thus preventing any potential null pointer dereference issues.

- Move the null check for `pathptr` from line 2151 to before the dereference on line 1954.
- Ensure that the logic remains consistent and that the null check is properly placed to prevent any null pointer dereference.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
