### PR TITLE
Fix code scanning alert no. 133: Redundant null check due to previous dereference

### DIFF
--- a/windows/windDisp.c
+++ b/windows/windDisp.c
@@ -311,9 +311,11 @@ WindAreaChanged(w, area)
      * get left lying around.
      */
 
-    biggerArea = *area;
-    biggerArea.r_xtop += 1;
-    biggerArea.r_ytop += 1;
+    if (area != (Rect *) NULL) {
+        biggerArea = *area;
+        biggerArea.r_xtop += 1;
+        biggerArea.r_ytop += 1;
+    }
 
     /* If no window is given, or if the window is unobscured,
      * then just paint an error tile over the area to be redisplayed.

--- a/windows/windDisp.c
+++ b/windows/windDisp.c
@@ -19,6 +19,7 @@
 static char rcsid[] __attribute__ ((unused)) = "$Header$";
 #endif  /* not lint */
 
+#include <assert.h>
 #include <stdio.h>
 
 #include "tcltk/tclmagic.h"
@@ -311,11 +312,9 @@ WindAreaChanged(w, area)
      * get left lying around.
      */
 
-    if (area != (Rect *) NULL) {
-        biggerArea = *area;
-        biggerArea.r_xtop += 1;
-        biggerArea.r_ytop += 1;
-    }
+    biggerArea = *area;
+    biggerArea.r_xtop += 1;
+    biggerArea.r_ytop += 1;
 
     /* If no window is given, or if the window is unobscured,
      * then just paint an error tile over the area to be redisplayed.
@@ -339,9 +338,11 @@ WindAreaChanged(w, area)
     /* will be copied into on the next display redraw.			*/
 
     if ((w != NULL) && (w->w_backingStore == (ClientData)NULL) &&
-		(!(w->w_flags & WIND_OBSCURED)) && (GrCreateBackingStorePtr != NULL))
-	if ((area == (Rect *)NULL) || GEO_SURROUND(&biggerArea, &w->w_screenArea))
+		(!(w->w_flags & WIND_OBSCURED)) && (GrCreateBackingStorePtr != NULL)) {
+	assert(area); // area is non-null
+	if (GEO_SURROUND(&biggerArea, &w->w_screenArea))
 	    (*GrCreateBackingStorePtr)(w);
+    }
 }
 
 int


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/133](https://github.com/dlmiles/magic/security/code-scanning/133)

To fix the problem, we need to move the null check for `area` before its dereference. This ensures that we do not attempt to dereference a null pointer, which would lead to undefined behavior. Specifically, we should check if `area` is null before line 314 and handle it appropriately. If `area` is null, we should assign it a valid value before dereferencing it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
