### PR TITLE
Fix code scanning alert no. 97: Wrong type of arguments to formatting function

### DIFF
--- a/gcr/gcrDebug.c
+++ b/gcr/gcrDebug.c
@@ -106,7 +106,7 @@ GCRRouteFromFile(fname)
     (void) GCRroute(ch);
     times(&tbuf2);
     TxPrintf("Time   :  %5.2fu  %5.2fs\n", (tbuf2.tms_utime -
-	    tbuf1.tms_utime)/60.0, (tbuf2.tms_stime-tbuf1.tms_stime)*60);
+	    tbuf1.tms_utime)/60.0, (double)(tbuf2.tms_stime-tbuf1.tms_stime)*60);
 
     gcrDumpResult(ch, GcrShowEnd);
     gcrShowMap(ch);


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/97](https://github.com/dlmiles/magic/security/code-scanning/97)

To fix the problem, we need to ensure that the format specifier matches the type of the argument being passed to `TxPrintf`. Since the expression `(tbuf2.tms_stime - tbuf1.tms_stime) * 60` results in a `long`, we should convert this value to a `double` before passing it to `TxPrintf`. This can be done by casting the result to `double`.

The specific change involves modifying the argument `(tbuf2.tms_stime - tbuf1.tms_stime) * 60` to `(double)(tbuf2.tms_stime - tbuf1.tms_stime) * 60` on line 109 in the file `gcr/gcrDebug.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
