### PR TITLE
Fix code scanning alert no. 131: Wrong type of arguments to formatting function

### DIFF
--- a/windows/windDebug.c
+++ b/windows/windDebug.c
@@ -54,7 +54,7 @@ windPrintWindow(w)
     LinkedRect *lr;
 
     TxPrintf("\nWindow %d: '%s'\n", w->w_wid, w->w_caption);
-    TxPrintf("  Client %x  Surface %x \n", w->w_client, w->w_surfaceID);
+    TxPrintf("  Client %x  Surface %lx \n", w->w_client, w->w_surfaceID);
 
     TxPrintf("  All area (%d, %d) (%d, %d)\n",
 	w->w_allArea.r_xbot, w->w_allArea.r_ybot,


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/131](https://github.com/dlmiles/magic/security/code-scanning/131)

To fix the problem, we need to ensure that the format specifier in the `TxPrintf` function call matches the type of the argument being passed. Specifically, we should change the format specifier from `%x` to `%lx` for the `w_surfaceID` argument, which is of type `unsigned long`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
