### PR TITLE
Fix code scanning alert no. 130: Wrong type of arguments to formatting function

### DIFF
--- a/windows/windDebug.c
+++ b/windows/windDebug.c
@@ -54,7 +54,7 @@ windPrintWindow(w)
     LinkedRect *lr;
 
     TxPrintf("\nWindow %d: '%s'\n", w->w_wid, w->w_caption);
-    TxPrintf("  Client %x  Surface %x \n", w->w_client, w->w_surfaceID);
+    TxPrintf("  Client %lx  Surface %lx \n", w->w_client, w->w_surfaceID);
 
     TxPrintf("  All area (%d, %d) (%d, %d)\n",
 	w->w_allArea.r_xbot, w->w_allArea.r_ybot,


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/130](https://github.com/dlmiles/magic/security/code-scanning/130)

To fix the problem, we need to update the format specifier in the `TxPrintf` function call to match the type of the variable `w->w_client`. Specifically, we should change the format specifier from `%x` to `%lx` to correctly handle the `unsigned long` type.

- Locate the `TxPrintf` function call on line 57 in the file `windows/windDebug.c`.
- Change the format specifier for `w->w_client` from `%x` to `%lx`.
- Ensure that the format specifier for `w->w_surfaceID` is also updated if it is of type `unsigned long`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
