### PR TITLE
Fix code scanning alert no. 98: Wrong type of arguments to formatting function

### DIFF
--- a/graphics/grTk1.c
+++ b/graphics/grTk1.c
@@ -535,7 +535,7 @@ GrTkInit(dispType)
 	}
 	else
 	{
-	    TxPrintf("Using %s, VisualID 0x%x depth %d\n",
+	    TxPrintf("Using %s, VisualID 0x%lx depth %d\n",
 		visual_type[grvisual_get[gritems].class],
 		grvisual_get[gritems].visualid,
 		grvisual_get[gritems].depth);


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/98](https://github.com/dlmiles/magic/security/code-scanning/98)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `grvisual_get[gritems].visualid` is of type `unsigned long`, we should use the `%lx` format specifier, which is designed for `unsigned long` values.

- Update the format specifier in the `TxPrintf` function call on line 540 to `%lx`.
- Ensure that the change is made only to the relevant line to avoid altering the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
