### PR TITLE
Fix code scanning alert no. 67: Wrong type of arguments to formatting function

### DIFF
--- a/debug/debugFlags.c
+++ b/debug/debugFlags.c
@@ -208,7 +208,7 @@ DebugSet(clientID, argc, argv, value)
 
     if (id < 0 || id >= debugNumClients)
     {
-	TxError("DebugSet: bad client id %d\n", clientID);
+	TxError("DebugSet: bad client id %lu\n", (unsigned long)clientID);
 	return;
     }
     dc = &debugClients[id];


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/67](https://github.com/dlmiles/magic/security/code-scanning/67)

To fix the problem, we need to ensure that the format specifier in the `TxError` function call matches the type of `clientID`. If `ClientData` is an `unsigned long`, we should use the `%lu` format specifier. This change will ensure that the argument is correctly interpreted by the `TxError` function, preventing undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
