### PR TITLE
Fix code scanning alert no. 68: Wrong type of arguments to formatting function

### DIFF
--- a/debug/debugFlags.c
+++ b/debug/debugFlags.c
@@ -121,7 +121,7 @@ DebugAddFlag(clientID, name)
 
     if (id < 0 || id >= debugNumClients)
     {
-	TxError("DebugAddFlag: bad client id %d (flag %s)\n", clientID, name);
+	TxError("DebugAddFlag: bad client id %lu (flag %s)\n", clientID, name);
 	return (0);
     }
 
@@ -165,7 +165,7 @@ DebugShow(clientID)
 
     if (id < 0 || id >= debugNumClients)
     {
-	TxError("DebugShow: bad client id %d\n", clientID);
+	TxError("DebugShow: bad client id %lu\n", clientID);
 	return;
     }
     dc = &debugClients[id];


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/68](https://github.com/dlmiles/magic/security/code-scanning/68)

To fix the problem, we need to ensure that the format specifier in the `TxError` function matches the type of `clientID`. If `ClientData` is an unsigned long, we should use `%lu` as the format specifier. If it is a pointer, we should use `%p`. Given the context, it is more likely that `ClientData` is an unsigned long.

- Change the format specifier from `%d` to `%lu` in the `TxError` function calls.
- Specifically, update the format specifier on line 168 and line 124.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
