### PR TITLE
Fix code scanning alert no. 55: Multiplication result converted to larger type

### DIFF
--- a/plot/plotPNM.c
+++ b/plot/plotPNM.c
@@ -877,7 +877,7 @@ PlotPNM(fileName, scx, layers, xMask, width)
 	/* Clear tile memory with the background gray level */
 
 	memset((void *)rtile, PlotPNMBG,
-		(size_t)(ds_xsize * ds_ysize * PIXELSZ));
+		(size_t)ds_xsize * ds_ysize * PIXELSZ);
 
 	if (SigInterruptPending)
 	{


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/55](https://github.com/dlmiles/magic/security/code-scanning/55)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. We can cast one of the operands to `size_t` before performing the multiplication. This will promote the multiplication to `size_t`, which has a larger range and can accommodate larger values without overflow.

Specifically, we will change the line:
```c
memset((void *)rtile, PlotPNMBG, (size_t)(ds_xsize * ds_ysize * PIXELSZ));
```
to:
```c
memset((void *)rtile, PlotPNMBG, (size_t)ds_xsize * ds_ysize * PIXELSZ);
```

This ensures that the multiplication is done in the `size_t` type, preventing overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
