### PR TITLE
Fix code scanning alert no. 53: Multiplication result converted to larger type

### DIFF
--- a/lef/defWrite.c
+++ b/lef/defWrite.c
@@ -2285,8 +2285,7 @@ defCountCompFunc(cellUse, total)
     int sy = cellUse->cu_yhi - cellUse->cu_ylo + 1;
     // TxPrintf("Diagnostic: cell %s %d %d\n", cellUse->cu_id, sx, sy);
     ASSERT(sx >= 0 && sy >= 0, "Valid array");
-
-    (*total) += sx * sy;	/* Increment the count of uses */
+    (*total) += (unsigned long)sx * sy;	/* Increment the count of uses */
 
     return 0;	/* Keep the search going */
 }


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/53](https://github.com/dlmiles/magic/security/code-scanning/53)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `unsigned long` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly added to `*total`.

The specific change involves casting `sx` to `unsigned long` in the multiplication expression on line 2289.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
