### PR TITLE
Fix code scanning alert no. 52: Multiplication result converted to larger type

### DIFF
--- a/extract/ExtBasic.c
+++ b/extract/ExtBasic.c
@@ -612,7 +612,7 @@ extSetResist(reg)
 	reg->nreg_pa[n].pa_perim = perim = extResistPerim[n];
 	if (area > 0 && perim > 0)
 	{
-	    v = (double) (perim*perim - 16*area);
+	    v = (double) ((dlong)perim * perim - 16 * area);
 
 	    /* Approximate by one square if v < 0 */
 	    if (v < 0) s = 0; else s = sqrt(v);


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/52](https://github.com/dlmiles/magic/security/code-scanning/52)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `dlong` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly assigned to the `double` variable `v`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
