### PR TITLE
Fix code scanning alert no. 51: Multiplication result converted to larger type

### DIFF
--- a/extract/ExtCouple.c
+++ b/extract/ExtCouple.c
@@ -963,7 +963,7 @@ extRemoveSubcap(bp, clip, esws)
 
     if (dnear < 0) dnear = 0;	/* Don't count underlap */
     mult = ExtCurStyle->exts_overlapMult[ta][0];
-    snear = 0.6366 * atan(mult * dnear);
+    snear = 0.6366 * atan((double)mult * dnear);
 
     /* "snear" is the fractional portion of the fringe cap seen by	*/
     /* the substrate, so (1.0 - snear) is the part that is blocked.	*/


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/51](https://github.com/dlmiles/magic/security/code-scanning/51)

To fix the problem, we need to ensure that the multiplication is performed using the `double` type to avoid overflow. This can be achieved by casting one of the operands to `double` before the multiplication. This way, the multiplication will be done in the `double` type, which has a larger range and precision than `float`.

Specifically, we will cast `mult` to `double` before performing the multiplication with `dnear`. This change will be made on line 966 of the file `extract/ExtCouple.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
