### PR TITLE
Fix code scanning alert no. 50: Multiplication result converted to larger type

### DIFF
--- a/extflat/EFvisit.c
+++ b/extflat/EFvisit.c
@@ -789,7 +789,7 @@ EFNodeResist(node)
 	    if (v < 0.0) s = 0.0; else s = sqrt(v);
 
 	    fperim = (float) perim;
-	    dresist = (fperim + s)/(fperim - s) * efResists[n];
+	    dresist = ((double)fperim + (double)s)/((double)fperim - (double)s) * efResists[n];
 	    if (dresist + (double) resist > (double) INT_MAX)
 		resist = INT_MAX;
 	    else


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/50](https://github.com/dlmiles/magic/security/code-scanning/50)

To fix the problem, we need to ensure that the multiplication is performed using `double` precision to avoid any overflow. This can be achieved by casting the variables involved in the multiplication to `double` before performing the operation. Specifically, we should cast `fperim` and `s` to `double` before the multiplication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
