### PR TITLE
Fix code scanning alert no. 49: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -2212,8 +2212,8 @@ spcWriteParams(dev, hierName, scale, l, w, sdM)
 		if (esScale < 0)
 		    fprintf(esSpiceF, "%g", dev->dev_rect.r_ybot * scale);
 		else if (plist->parm_scale != 1.0)
-		    fprintf(esSpiceF, "%g", dev->dev_rect.r_ybot * scale
-				* esScale * plist->parm_scale * 1E-6);
+		    fprintf(esSpiceF, "%g", (double)dev->dev_rect.r_ybot * (double)scale
+				* (double)esScale * (double)plist->parm_scale * 1E-6);
 		else
 		    esSIvalue(esSpiceF, (dev->dev_rect.r_ybot + plist->parm_offset)
 				* scale * esScale * 1.0E-6);


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/49](https://github.com/dlmiles/magic/security/code-scanning/49)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (double) to avoid overflow. This can be achieved by casting one of the operands to double before performing the multiplication. Specifically, we should cast `scale` to double before multiplying it with `dev->dev_rect.r_ybot`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
