### PR TITLE
Fix code scanning alert no. 35: Multiplication result converted to larger type

### DIFF
--- a/drc/DRCbasic.c
+++ b/drc/DRCbasic.c
@@ -176,7 +176,7 @@ areaCheck(tile, arg)
 	unsigned int i;
 	int sqx, sqy;
 	int sdist = arg->dCD_radial & 0xfff;
-	long sstest, ssdist = sdist * sdist;
+	long sstest, ssdist = (long) sdist * sdist;
 
 	if ((arg->dCD_radial & RADIAL_NW) != 0)
 	{


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/35](https://github.com/dlmiles/magic/security/code-scanning/35)

To fix the problem, we need to ensure that the multiplication is performed using the `long` type to avoid overflow. This can be achieved by casting one of the operands to `long` before the multiplication. Specifically, we will cast `sdist` to `long` in the expression `sdist * sdist`. This change will ensure that the multiplication is done using the `long` type, preventing any overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
