### PR TITLE
Fix code scanning alert no. 34: Multiplication result converted to larger type

### DIFF
--- a/drc/DRCcif.c
+++ b/drc/DRCcif.c
@@ -1076,7 +1076,7 @@ areaCifCheck(tile, arg)
 	unsigned int i;
 	int sqx, sqy;
 	int sdist = arg->dCD_radial & 0xfff;
-	long sstest, ssdist = sdist * sdist;
+	long sstest, ssdist = (long) sdist * sdist;
 
 	if ((arg->dCD_radial & RADIAL_NW) != 0)
 	{


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/34](https://github.com/dlmiles/magic/security/code-scanning/34)

To fix the problem, we need to ensure that the multiplication is performed using the `long` type to avoid overflow. This can be achieved by casting one of the operands to `long` before performing the multiplication. This way, the multiplication will be done in the `long` type, preventing any overflow that could occur if the multiplication were done in the `int` type.

Specifically, we will modify line 1079 in the file `drc/DRCcif.c` to cast `sdist` to `long` before performing the multiplication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
