### PR TITLE
Fix code scanning alert no. 54: Multiplication result converted to larger type

### DIFF
--- a/plot/plotRutils.c
+++ b/plot/plotRutils.c
@@ -519,7 +519,7 @@ PlotDumpRaster(raster, file)
     int count;
 
     count = write(fileno(file), (char *) raster->ras_bits,
-	    raster->ras_bytesPerLine*raster->ras_height);
+	    (size_t)raster->ras_bytesPerLine * raster->ras_height);
     if (count < 0)
     {
 	TxError("I/O error in writing raster file:  %s.\n",


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/54](https://github.com/dlmiles/magic/security/code-scanning/54)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, avoiding overflow.

Specifically, we will cast `raster->ras_bytesPerLine` to `size_t` before multiplying it by `raster->ras_height` on line 522. This change will ensure that the multiplication is safe and the result is correctly stored in `count`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
