### PR TITLE
Fix code scanning alert no. 36: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -167,13 +167,13 @@ spcHierWriteParams(hc, dev, scale, l, w, sdM)
 		    fprintf(esSpiceF, " %s=", plist->parm_name);
 		    parmval = dev->dev_area;
 		    if (esScale < 0)
-			fprintf(esSpiceF, "%g", parmval * scale * scale);
+		    fprintf(esSpiceF, "%g", (double)parmval * scale * scale);
 		    else if (plist->parm_scale != 1.0)
-			fprintf(esSpiceF, "%g", parmval * scale * scale
+			fprintf(esSpiceF, "%g", (double)parmval * scale * scale
 				* esScale * esScale * plist->parm_scale
 				* 1E-12);
 		    else
-			esSIvalue(esSpiceF, 1.0E-12 * (parmval + plist->parm_offset)
+			esSIvalue(esSpiceF, 1.0E-12 * ((double)parmval + plist->parm_offset)
 				* scale * scale * esScale * esScale);
 		}
 		else


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/36](https://github.com/dlmiles/magic/security/code-scanning/36)

To fix the problem, we need to ensure that the multiplication is performed using a larger type to prevent overflow. This can be achieved by casting one of the operands to a `double` before performing the multiplication. This way, the multiplication will be done in the `double` type, which has a much larger range than `int`.

Specifically, we will cast `parmval` to `double` before performing the multiplication. This change should be made in the relevant lines where the multiplication occurs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
