### PR TITLE
Fix code scanning alert no. 37: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -217,11 +217,11 @@ spcHierWriteParams(hc, dev, scale, l, w, sdM)
 		    if (esScale < 0)
 			fprintf(esSpiceF, "%g", parmval * scale);
 		    else if (plist->parm_scale != 1.0)
-			fprintf(esSpiceF, "%g", parmval * scale
-				* esScale * plist->parm_scale * 1E-6);
+			fprintf(esSpiceF, "%g", (double)parmval * (double)scale
+				* (double)esScale * (double)plist->parm_scale * 1E-6);
 		    else
-			esSIvalue(esSpiceF, (parmval + plist->parm_offset)
-				* scale * esScale * 1.0E-6);
+			esSIvalue(esSpiceF, ((double)parmval + (double)plist->parm_offset)
+				* (double)scale * (double)esScale * 1.0E-6);
 		}
 		else
 		{


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/37](https://github.com/dlmiles/magic/security/code-scanning/37)

To fix the problem, we need to ensure that the multiplication is performed using the `double` type to avoid overflow. This can be achieved by casting the variables involved in the multiplication to `double` before performing the operation. This way, the multiplication will be done in the `double` type, which has a larger range and can handle larger values without overflow.

Specifically, we need to modify the multiplication expressions on lines 220 and 223 to cast the variables to `double` before multiplying them. This will ensure that the multiplication is performed using the `double` type, preventing overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
