### PR TITLE
Fix code scanning alert no. 43: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -2011,8 +2011,8 @@ spcWriteParams(dev, hierName, scale, l, w, sdM)
 		    if (esScale < 0)
 			fprintf(esSpiceF, "%g", parmval * scale * scale);
 		    else if (plist->parm_scale != 1.0)
-			fprintf(esSpiceF, "%g", parmval * scale * scale
-				* esScale * esScale * plist->parm_scale
+			fprintf(esSpiceF, "%g", (double)parmval * (double)scale * (double)scale
+				* (double)esScale * (double)esScale * (double)plist->parm_scale
 				* 1E-12);
 		    else
 			esSIvalue(esSpiceF, 1.0E-12 * (parmval + plist->parm_offset)


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/43](https://github.com/dlmiles/magic/security/code-scanning/43)

To fix the problem, we need to ensure that the multiplication is performed using `double` precision to avoid overflow. This can be achieved by casting the variables involved in the multiplication to `double` before performing the multiplication. This way, the multiplication will be done using `double` precision, preventing overflow.

Specifically, we need to modify the multiplication on line 2014 to cast the variables to `double` before multiplying them. This change should be made in the file `ext2spice/ext2spice.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
