### PR TITLE
Fix code scanning alert no. 44: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -2078,7 +2078,7 @@ spcWriteParams(dev, hierName, scale, l, w, sdM)
 		    if (esScale < 0)
 			fprintf(esSpiceF, "%g", parmval * scale);
 		    else if (plist->parm_scale != 1.0)
-			fprintf(esSpiceF, "%g", parmval * scale
+			fprintf(esSpiceF, "%g", (double)parmval * scale
 				* esScale * plist->parm_scale * 1E-6);
 		    else
 			esSIvalue(esSpiceF, 1.0E-12 * (parmval + plist->parm_offset)


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/44](https://github.com/dlmiles/magic/security/code-scanning/44)

To fix the problem, we need to ensure that the multiplication is performed using the `double` type to avoid overflow. This can be achieved by casting one of the operands to `double` before performing the multiplication. This way, the multiplication will be done in the `double` type, preventing overflow.

- **General Fix:** Cast one of the operands to `double` before performing the multiplication.
- **Detailed Fix:** In the specific line flagged by CodeQL, cast `parmval` to `double` before multiplying it with `scale`, `esScale`, and `plist->parm_scale`.
- **Lines to Change:** Modify line 2081 in the file `ext2spice/ext2spice.c`.
- **Required Changes:** No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
