### PR TITLE
Fix code scanning alert no. 45: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -2142,7 +2142,7 @@ spcWriteParams(dev, hierName, scale, l, w, sdM)
 		    if (esScale < 0)
 			fprintf(esSpiceF, "%g", l * scale);
 		    else if (plist->parm_scale != 1.0)
-			fprintf(esSpiceF, "%g", l * scale * esScale
+			fprintf(esSpiceF, "%g", (double)l * scale * esScale
 				* plist->parm_scale * 1E-6);
 		    else
 			esSIvalue(esSpiceF, 1.0E-6 * (l + plist->parm_offset)


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/45](https://github.com/dlmiles/magic/security/code-scanning/45)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (`double`) to avoid overflow. This can be achieved by casting one of the operands to `double` before performing the multiplication. This way, the multiplication will be done in `double` precision, preventing overflow.

Specifically, we will cast `l` to `double` before the multiplication on line 2145. This ensures that the entire multiplication is performed in `double` precision.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
