### PR TITLE
Fix code scanning alert no. 48: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2spice.c
+++ b/ext2spice/ext2spice.c
@@ -2201,7 +2201,7 @@ spcWriteParams(dev, hierName, scale, l, w, sdM)
 		if (esScale < 0)
 		    fprintf(esSpiceF, "%g", dev->dev_rect.r_xbot * scale);
 		else if (plist->parm_scale != 1.0)
-		    fprintf(esSpiceF, "%g", dev->dev_rect.r_xbot * scale
+		    fprintf(esSpiceF, "%g", (double)dev->dev_rect.r_xbot * scale
 				* esScale * plist->parm_scale * 1E-6);
 		else
 		    esSIvalue(esSpiceF, (dev->dev_rect.r_xbot + plist->parm_offset)


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/48](https://github.com/dlmiles/magic/security/code-scanning/48)

To fix the problem, we need to ensure that the multiplication is performed using the `double` type to avoid overflow. This can be achieved by casting one of the operands to `double` before performing the multiplication. This way, the entire multiplication operation will be carried out in the `double` type, preventing overflow.

Specifically, we will cast `dev->dev_rect.r_xbot` to `double` before performing the multiplication on line 2204. This ensures that the multiplication is done using `double` precision.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
