### PR TITLE
Fix code scanning alert no. 40: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -304,7 +304,7 @@ spcHierWriteParams(hc, dev, scale, l, w, sdM)
 		if (esScale < 0)
 		    fprintf(esSpiceF, "%g", w * scale);
 		else if (plist->parm_scale != 1.0)
-		    fprintf(esSpiceF, "%g", w * scale * esScale
+		    fprintf(esSpiceF, "%g", (double)w * scale * esScale
 				* plist->parm_scale * 1E-6);
 		else
 		    esSIvalue(esSpiceF, 1.0E-6 * (w + plist->parm_offset)


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/40](https://github.com/dlmiles/magic/security/code-scanning/40)

To fix the problem, we need to ensure that the multiplication is performed using the `double` type to prevent overflow. This can be achieved by casting one of the operands to `double` before performing the multiplication. This way, the multiplication will be done in `double` precision, avoiding overflow.

The best way to fix this is to cast `w` to `double` before the multiplication. This change should be made in the file `ext2spice/ext2hier.c` on line 307.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
