### PR TITLE
Fix code scanning alert no. 42: Multiplication result converted to larger type

### DIFF
--- a/ext2spice/ext2hier.c
+++ b/ext2spice/ext2hier.c
@@ -332,8 +332,8 @@ spcHierWriteParams(hc, dev, scale, l, w, sdM)
 		if (esScale < 0)
 		    fprintf(esSpiceF, "%g", dev->dev_rect.r_ybot * scale);
 		else if (plist->parm_scale != 1.0)
-		    fprintf(esSpiceF, "%g", dev->dev_rect.r_ybot * scale
-				* esScale * plist->parm_scale * 1E-6);
+		    fprintf(esSpiceF, "%g", (double)dev->dev_rect.r_ybot * (double)scale
+				* (double)esScale * (double)plist->parm_scale * 1E-6);
 		else
 		    esSIvalue(esSpiceF, (dev->dev_rect.r_ybot + plist->parm_offset)
 				* scale * esScale * 1.0E-6);


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/42](https://github.com/dlmiles/magic/security/code-scanning/42)

To fix the problem, we need to ensure that the multiplication is performed using `double` precision to avoid overflow. This can be achieved by casting the operands to `double` before performing the multiplication. This way, the multiplication will be done using `double` precision, and the risk of overflow will be mitigated.

Specifically, we need to modify the lines where the multiplication occurs to cast the operands to `double`. This involves changing lines 335 and 336 to ensure that the multiplication is done in `double` precision.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
