### PR TITLE
Fix code scanning alert no. 159: Wrong type of arguments to formatting function

### DIFF
--- a/extract/ExtHier.c
+++ b/extract/ExtHier.c
@@ -854,7 +854,7 @@ extOutputConns(table, outf)
 		fprintf(outf, "merge \"%s\" \"%s\" %lg",
 				nn->nn_name, nnext->nn_name, c);
 		for (n = 0; n < ExtCurStyle->exts_numResistClasses; n++)
-		    fprintf(outf, " %ld %ld",
+		    fprintf(outf, " %ld %d",
 				node->node_pa[n].pa_area,
 				node->node_pa[n].pa_perim);
 		fprintf(outf, "\n");


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/159](https://github.com/dlmiles/magic/security/code-scanning/159)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since CodeQL has flagged that `node->node_pa[n].pa_perim` is of type `int`, we should use the `%d` format specifier instead of `%ld`. This change will ensure that the `fprintf` function interprets the argument correctly, preventing undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
