### PR TITLE
Fix code scanning alert no. 56: Multiplication result converted to larger type

### DIFF
--- a/plot/plotRutils.c
+++ b/plot/plotRutils.c
@@ -231,7 +231,7 @@ PlotClearRaster(raster, area)
     if (area == NULL)
     {
 	bzero((char *) raster->ras_bits,
-		raster->ras_bytesPerLine * raster->ras_height);
+		(size_t)raster->ras_bytesPerLine * raster->ras_height);
 	return;
     }
 


### PR DESCRIPTION
Fixes [https://github.com/dlmiles/magic/security/code-scanning/56](https://github.com/dlmiles/magic/security/code-scanning/56)

To fix the problem, we need to ensure that the multiplication is performed using a larger type before the result is converted to `size_t`. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

Specifically, we will cast `raster->ras_bytesPerLine` to `size_t` before multiplying it by `raster->ras_height` on line 234.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
